### PR TITLE
feat: add support for `identifierBase`

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,8 @@ Options:
                                           Defaults to "true" when "org" is set, false otherwise
   -o, --org <string>                      The NPM org scope that should be used WITHOUT "@" sign or trailing "/"
   --preid [string]                        The "prerelease identifier" to use as a prefix for the "prerelease" part of a semver
+  --identifier-base <string>              The base number (0 or 1) to be used for the prerelease identifier.
+  --no-identifier-base                    Do not use a base number for the prerelease identifier.
   -c, --commit-message-template [string]  A custom commit message template to use.
                                           Defaults to "chore({{name}}): release {{full-name}}@{{new-version}}"
                                           You can use "{{new-version}}" in your template which will be dynamically replaced with whatever the new version is that will be published.
@@ -136,6 +138,7 @@ package). It should be named `.cliff-jumperrc`, optionally suffixed with
 - `--mono-repo` and `--no-mono-repo` map to `monoRepo`
 - `--org` maps to `org`
 - `--preid` maps to `preid`
+- `--identifier-base` and `--no-identifier-base` map to `identifierBase`
 - `--commit-message-template` maps to `commitMessageTemplate`
 - `--tag-template` maps to `tagTemplate`
 - `--install` map to `install`
@@ -188,6 +191,8 @@ This library has opinionated defaults for its options. These are as follows:
 - `--first-release` will default to `undefined`.
 - `--org` will default to `undefined`.
 - `--preid` will default to `undefined`.
+- `--identifier-base` will default to `undefined`. Alternatively, you can force
+  this to `false` by providing `--no-identifier-base`.
 - `--install` will default to `undefined`.
 - `--skip-changelog` will default to `false` (`true` when `CI` environment
   variable is `'true'`). Alternatively you can force this to false by providing

--- a/assets/cliff-jumper.schema.json
+++ b/assets/cliff-jumper.schema.json
@@ -33,6 +33,10 @@
       "description": "The \"prerelease identifier\" to use as a prefix for the \"prerelease\" part of a semver",
       "type": "string"
     },
+    "identifierBase": {
+      "description": "The base number (0 or 1) to be used for the \"prerelease identifier\". Supply `false` to not use one.",
+      "type": ["boolean", "string"]
+    },
     "commitMessageTemplate": {
       "description": "A custom commit message template to use.\nDefaults to \"chore({{name}}): release {{full-name}}@{{new-version}}\"\n\nYou can use \"{{new-version}}\" in your template which will be dynamically replaced with whatever the new version is that will be published.\n\nYou can use \"{{name}}\" in your template, this will be replaced with the name provided through \"-n\", \"--name\" or the same value set in your config file.\n\nYou can use \"{{full-name}}\" in your template, this will be replaced \"{{name}}\" (when \"org\" is not provided), or \"@{{org}}/{{name}}\" (when \"org\" is provided).",
       "type": "string"

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -22,7 +22,7 @@ import {
 } from '#lib/utils';
 import { isNullishOrEmpty } from '@sapphire/utilities';
 import { blue, blueBright, cyan, green, yellow } from 'colorette';
-import { Command } from 'commander';
+import { Command, InvalidArgumentError } from 'commander';
 import { readFile } from 'node:fs/promises';
 import { URL } from 'node:url';
 
@@ -58,6 +58,11 @@ const command = new Command()
   .option('--no-mono-repo', monoRepoDescription)
   .option('-o, --org <string>', 'The NPM org scope that should be used WITHOUT "@" sign or trailing "/"')
   .option('--preid [string]', 'The "prerelease identifier" to use as a prefix for the "prerelease" part of a semver')
+  .option('--identifier-base <number>', 'The base number (0 or 1) to be used for the prerelease identifier.', (input) => {
+    if (input === '0' || input === '1') return input;
+    throw new InvalidArgumentError('Not a number of 0 or 1.');
+  })
+  .option('--no-identifier-base', 'Do not use a base number for the prerelease identifier.')
   .option(
     '-c, --commit-message-template [string]',
     [
@@ -103,6 +108,7 @@ logVerboseInfo(
     `${indent}mono repo: ${JSON.stringify(options.monoRepo)}`,
     `${indent}npm org: ${JSON.stringify(options.org)}`,
     `${indent}preid: ${JSON.stringify(options.preid)}`,
+    `${indent}identifier base: ${JSON.stringify(options.identifierBase)}`,
     `${indent}commit message template: ${JSON.stringify(options.commitMessageTemplate)}`,
     `${indent}tag template: ${JSON.stringify(options.tagTemplate)}`,
     `${indent}install: ${JSON.stringify(options.install)}`,

--- a/src/commands/bump-version.ts
+++ b/src/commands/bump-version.ts
@@ -24,7 +24,7 @@ export function bumpVersion(options: Options, releaseType: Recommendation.Releas
       });
     }
 
-    const newVersion = Semver.inc(currentClean, `${getReleaseType(options, releaseType)}`, options.preid ?? '');
+    const newVersion = Semver.inc(currentClean, `${getReleaseType(options, releaseType)}`, options.preid ?? '', options.identifierBase);
 
     if (isNullishOrEmpty(newVersion)) {
       return logVerboseError({

--- a/src/lib/interfaces.d.ts
+++ b/src/lib/interfaces.d.ts
@@ -1,3 +1,5 @@
+import type { IdentifierBase } from 'semver/functions/inc.js';
+
 export default undefined;
 
 declare module 'commander' {
@@ -6,6 +8,7 @@ declare module 'commander' {
     org: string;
     packagePath: string;
     preid: string;
+    identifierBase: IdentifierBase | false;
     dryRun: boolean;
     verbose: boolean;
     skipChangelog: boolean;


### PR DESCRIPTION
cliff-jumper does the following to bump the version:

https://github.com/favware/cliff-jumper/blob/46993f1ce0de3a2a8c9cf1a2beefe4a7ab12971c/src/commands/bump-version.ts#L27

There is another parameter called [`identifierBase`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/d2fedd883d5a1c62a1c90629c50b3a2b318307a6/types/semver/functions/inc.d.ts#L22). Most notably, setting this to `false` would remove the identifier base.

Examples:

```JavaScript
inc("14.13.0", "preminor", "dev-1e5c14b74"); // 14.14.0-dev-1e5c14b74.0
inc("14.13.0", "preminor", "dev-1e5c14b74", "0"); // 14.14.0-dev-1e5c14b74.0
inc("14.13.0", "preminor", "dev-1e5c14b74", "1"); // 14.14.0-dev-1e5c14b74.1
inc("14.13.0", "preminor", "dev-1e5c14b74", false); // 14.14.0-dev-1e5c14b74
```

This pull request aims to utilise this parameter.
