### PR TITLE
fix(deps): update dependency git-cliff to ^2.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "compare-func": "^2.0.0",
     "conventional-recommended-bump": "^9.0.0",
     "execa": "^8.0.1",
-    "git-cliff": "^2.2.0",
+    "git-cliff": "^2.2.1",
     "js-yaml": "^4.1.0",
     "semver": "^7.6.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -302,7 +302,7 @@ __metadata:
     eslint-config-prettier: "npm:^9.1.0"
     eslint-plugin-prettier: "npm:^5.1.3"
     execa: "npm:^8.0.1"
-    git-cliff: "npm:^2.2.0"
+    git-cliff: "npm:^2.2.1"
     js-yaml: "npm:^4.1.0"
     lint-staged: "npm:^15.2.2"
     prettier: "npm:^3.2.5"
@@ -1872,59 +1872,59 @@ __metadata:
   languageName: node
   linkType: hard
 
-"git-cliff-darwin-arm64@npm:2.2.0":
-  version: 2.2.0
-  resolution: "git-cliff-darwin-arm64@npm:2.2.0"
+"git-cliff-darwin-arm64@npm:2.2.1":
+  version: 2.2.1
+  resolution: "git-cliff-darwin-arm64@npm:2.2.1"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
 
-"git-cliff-darwin-x64@npm:2.2.0":
-  version: 2.2.0
-  resolution: "git-cliff-darwin-x64@npm:2.2.0"
+"git-cliff-darwin-x64@npm:2.2.1":
+  version: 2.2.1
+  resolution: "git-cliff-darwin-x64@npm:2.2.1"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
 
-"git-cliff-linux-arm64@npm:2.2.0":
-  version: 2.2.0
-  resolution: "git-cliff-linux-arm64@npm:2.2.0"
+"git-cliff-linux-arm64@npm:2.2.1":
+  version: 2.2.1
+  resolution: "git-cliff-linux-arm64@npm:2.2.1"
   conditions: os=linux & cpu=arm64
   languageName: node
   linkType: hard
 
-"git-cliff-linux-x64@npm:2.2.0":
-  version: 2.2.0
-  resolution: "git-cliff-linux-x64@npm:2.2.0"
+"git-cliff-linux-x64@npm:2.2.1":
+  version: 2.2.1
+  resolution: "git-cliff-linux-x64@npm:2.2.1"
   conditions: os=linux & cpu=x64
   languageName: node
   linkType: hard
 
-"git-cliff-windows-arm64@npm:2.2.0":
-  version: 2.2.0
-  resolution: "git-cliff-windows-arm64@npm:2.2.0"
+"git-cliff-windows-arm64@npm:2.2.1":
+  version: 2.2.1
+  resolution: "git-cliff-windows-arm64@npm:2.2.1"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
 
-"git-cliff-windows-x64@npm:2.2.0":
-  version: 2.2.0
-  resolution: "git-cliff-windows-x64@npm:2.2.0"
+"git-cliff-windows-x64@npm:2.2.1":
+  version: 2.2.1
+  resolution: "git-cliff-windows-x64@npm:2.2.1"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
 
-"git-cliff@npm:^2.2.0":
-  version: 2.2.0
-  resolution: "git-cliff@npm:2.2.0"
+"git-cliff@npm:^2.2.1":
+  version: 2.2.1
+  resolution: "git-cliff@npm:2.2.1"
   dependencies:
     execa: "npm:^8.0.1"
-    git-cliff-darwin-arm64: "npm:2.2.0"
-    git-cliff-darwin-x64: "npm:2.2.0"
-    git-cliff-linux-arm64: "npm:2.2.0"
-    git-cliff-linux-x64: "npm:2.2.0"
-    git-cliff-windows-arm64: "npm:2.2.0"
-    git-cliff-windows-x64: "npm:2.2.0"
+    git-cliff-darwin-arm64: "npm:2.2.1"
+    git-cliff-darwin-x64: "npm:2.2.1"
+    git-cliff-linux-arm64: "npm:2.2.1"
+    git-cliff-linux-x64: "npm:2.2.1"
+    git-cliff-windows-arm64: "npm:2.2.1"
+    git-cliff-windows-x64: "npm:2.2.1"
   dependenciesMeta:
     git-cliff-darwin-arm64:
       optional: true
@@ -1940,7 +1940,7 @@ __metadata:
       optional: true
   bin:
     git-cliff: lib/cli/cli.js
-  checksum: 10/fe698b5463345b80455629cd8768bfc84028ef4005a6bf7959f6f09540cd7ce50b60d65a4b11323b11fdcb9b3a3a1af93d22d8198529d9572cea55b38fe68e68
+  checksum: 10/c69a790137a058b46c7f09da736150d74ee52e6c72050fa4226bf80d9f6154d2dbb8169175610271ec9da26e2ef4b5090928bcab2e0150f58ac4446abb6ff331
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This pull request updates `git-cliff` to `^2.2.1` which fixes an issue with `^2.2.0`, see https://github.com/orhun/git-cliff/issues/591