### PR TITLE
fix(commit-release): remove quotes from commit message template

### DIFF
--- a/src/commands/commit-release.ts
+++ b/src/commands/commit-release.ts
@@ -15,7 +15,7 @@ export function commitRelease(options: Options, newVersion: string) {
 
   return doActionAndLog('Committing release', async () => {
     if (!options.dryRun) {
-      await execa('git', ['commit', '--no-verify', '-m', `"${options.commitMessageTemplate}"`]);
+      await execa('git', ['commit', '--no-verify', '-m', `${options.commitMessageTemplate}`]);
     }
   });
 }


### PR DESCRIPTION
Addresses an issue where commits are enclosed in double quotes, which appears to be an oversight introduced in https://github.com/favware/cliff-jumper/commit/74c09c7e1627f5a38af5de0579f8b90fe4d4f5cc.

I found this bug while releasing one of my packages in https://github.com/RealShadowNova/typedoc-json-parser/commit/3875bbd01d0f9fa15af4e53c954cee16b2ae00df.

It also appeared to happen in this repository too https://github.com/favware/cliff-jumper/commit/88ebba3108d070928d37cda4d84de47386cc72d6.

### Workaround

You can execute the following command to obtain the expected result. Remember to replace the placeholders with your project-specific values.
```
cliff-jumper --skip-tag && git commit -m 'your-commit-message' && git tag v1.0.0 && git push && git push --tags && yarn npm publish
```