### PR TITLE
feat: add commit skipping

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,16 +105,18 @@ Options:
                                                    Defaults to "chore({{name}}): release {{full-name}}@{{new-version}}"
                                                    You can use "{{new-version}}" in your template which will be dynamically replaced with whatever the new version is that will be published.
                                                    You can use "{{name}}" in your template, this will be replaced with the name provided through "-n", "--name" or the same value set in your config file.
-                                                   You can use "{{full-name}}" in your template, this will be replaced "{{name}}" (when "org" is not provided), or "@{{org}}/{{name}}" (when "org" is provided).
+                                                   You can use "{{full-name}}" in your template, this will be replaced "{{name}}" (when "org" is not provided), or "@{{org}}/{{name}}" (when "org" is
+                                                   provided).
   --tag-template [string]                          A custom tag template to use.
                                                    When "org" is provided this will default to "@{{org}}/{{name}}@{{new-version}}", for example "@favware/cliff-jumper@1.0.0"
                                                    When "org" is not provided this will default to "v{{new-version}}", for example "v1.0.0"
                                                    You can use "{{new-version}}" in your template which will be dynamically replaced with whatever the new version is that will be published.
                                                    You can use "{{org}}" in your template, this will be replaced with the org provided through "-o", "--org" or the same value set in your config file.
                                                    You can use "{{name}}" in your template, this will be replaced with the name provided through "-n", "--name" or the same value set in your config file.
-                                                   You can use "{{full-name}}" in your template, this will be replaced "{{name}}" (when "org" is not provided), or "@{{org}}/{{name}}" (when "org" is provided).
-  -i, --install                                    Whether to run npm install after bumping the version but before committing and creating a git tag. This is useful when you have a mono repo where bumping one package
-                                                   would then cause the lockfile to be out of date.
+                                                   You can use "{{full-name}}" in your template, this will be replaced "{{name}}" (when "org" is not provided), or "@{{org}}/{{name}}" (when "org" is
+                                                   provided).
+  -i, --install                                    Whether to run npm install after bumping the version but before committing and creating a git tag. This is useful when you have a mono repo where bumping
+                                                   one package would then cause the lockfile to be out of date.
   --skip-changelog                                 Whether to skip updating your changelog file
                                                    default "true" when CI=true, "false" otherwise
   --no-skip-changelog                              Whether to skip updating your changelog file
@@ -124,6 +126,7 @@ Options:
   --no-skip-tag                                    Whether to skip creating a git tag
                                                    default "true" when CI=true, "false" otherwise
   -cpf, --changelog-prepend-file [string]          The file that git-cliff should use for the --prepend flag, defaults to ./CHANGELOG.md. This should be relative to the current working directory.
+  --skip-commit [skipCommit...]                    Repeatable, each will be treated as a new entry. A list of SHA1 commit hashes that will be skipped in the changelog.
   --github-repo                                    The GitHub repository to use for linking to issues and PRs in the changelog.
                                                    You can pass the unique string "auto" to automatically set this value as {{org}}/{{name}} as provided from --org and --name
                                                    This should be in the format "owner/repo"
@@ -134,8 +137,8 @@ Options:
                                                    - GH_TOKEN
                                                    - TOKEN_GITHUB
                                                    - TOKEN_GH
-                                                   The multiple options for the name of the environment are to aim to not conflict with other tooling that use similar tokens in case you want to use a unique token for
-                                                   release management.
+                                                   The multiple options for the name of the environment are to aim to not conflict with other tooling that use similar tokens in case you want to use a unique
+                                                   token for release management.
   -pt, --push-tag                                  Whether to push the tag to the remote repository.
                                                    This will simply execute "git push && git push --tags" so make sure you have configured git for pushing properly beforehand.
   -npt, --no-push-tag                              Whether to push the tag to the remote repository.
@@ -148,13 +151,15 @@ Options:
                                                    If the changelog section from git-cliff is empty, the release notes will be auto-generated by GitHub.
   -ghrd, --github-release-draft                    Whether the release should be a draft
   -ghrpr, --github-release-pre-release             Whether the release should be a pre-release
-  -ghrl, --github-release-latest                   Whether the release should be marked as the latest release, will try to read this value, then the value of --github-release, and then default to false. Please note that
-                                                   when setting --github-release-pre-release to `true` GitHub will prevent the release to be marked as latest an this option will essentially be ignored.
+  -ghrl, --github-release-latest                   Whether the release should be marked as the latest release, will try to read this value, then the value of --github-release, and then default to false.
+                                                   Please note that when setting --github-release-pre-release to `true` GitHub will prevent the release to be marked as latest an this option will essentially
+                                                   be ignored.
   -ghrnt, --github-release-name-template [string]  A GitHub release name template to use. Defaults to an empty string, which means GitHub will use the tag name as the release name.
                                                    You can use "{{new-version}}" in your template which will be dynamically replaced with whatever the new version is that will be published.
                                                    You can use "{{org}}" in your template, this will be replaced with the org provided through "-o", "--org" or the same value set in your config file.
                                                    You can use "{{name}}" in your template, this will be replaced with the name provided through "-n", "--name" or the same value set in your config file.
-                                                   You can use "{{full-name}}" in your template, this will be replaced "{{name}}" (when "org" is not provided), or "@{{org}}/{{name}}" (when "org" is provided).
+                                                   You can use "{{full-name}}" in your template, this will be replaced "{{name}}" (when "org" is not provided), or "@{{org}}/{{name}}" (when "org" is
+                                                   provided).
   -v, --verbose                                    Whether to print verbose information (default: false)
   -h, --help                                       display help for command
 ```
@@ -180,6 +185,7 @@ package). It should be named `.cliff-jumperrc`, optionally suffixed with
 - `--skip-changelog` and `--no-skip-changelog` map to `skipChangelog`
 - `--skip-tag` and `--no-skip-tag` map to `skipTag`
 - `--changelog-prepend-file` maps to `changelogPrependFile`
+- `--skip-commit` maps to `skipCommit`
 - `--github-repo` maps to `githubRepo`
 - `--github-token` maps to `githubToken`
 - `--push-tag` and `--no-push-tag` map to `pushTag`
@@ -265,6 +271,7 @@ This library has opinionated defaults for its options. These are as follows:
   - `{{full-name}}` will be replaced with `{{name}}` (when `org` is not
     provided), or `@{{org}}/{{name}}` (when `org` is provided).
 - `--changelog-prepend-file` will default to `./CHANGELOG.md`.
+- `--skip-commit` will default to `[]` (an empty array).
 - `--github-repo` will default to `undefined`.
 - `--github-token` will default to `undefined`.
 - `--push-tag` will default to `false`. Alternatively you can force this to

--- a/assets/cliff-jumper.schema.json
+++ b/assets/cliff-jumper.schema.json
@@ -50,6 +50,14 @@
       "type": "string",
       "default": "./CHANGELOG.md"
     },
+    "skipCommit": {
+      "description": "Repeatable, each will be treated as a new entry. A list of SHA1 commit hashes that will be skipped in the changelog.",
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "default": []
+    },
     "githubRepo": {
       "description": "The GitHub repository to use for linking to issues and PRs in the changelog.\n\nYou can pass the unique string \"auto\" to automatically set this value as \"{{org}}/{{name}}\" as provided from \"--org\" and \"--name\". This should be in the format \"owner/repo\". You can use the \"GITHUB_REPO\" environment variable to automatically set this value",
       "type": "string"

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -119,6 +119,11 @@ const command = new Command()
     '-cpf, --changelog-prepend-file [string]',
     'The file that git-cliff should use for the --prepend flag, defaults to ./CHANGELOG.md. This should be relative to the current working directory.'
   )
+  .option(
+    '--skip-commit [skipCommit...]',
+    'Repeatable, each will be treated as a new entry. A list of SHA1 commit hashes that will be skipped in the changelog.',
+    (value: string, previous: string[]) => (previous ?? []).concat([value])
+  )
   .option('--github-repo', githubRepoDescription)
   .option(
     '--github-token',
@@ -173,6 +178,7 @@ logVerboseInfo(
     `${indent}install: ${JSON.stringify(options.install)}`,
     `${indent}skip changelog: ${JSON.stringify(options.skipChangelog)}`,
     `${indent}skip tag: ${JSON.stringify(options.skipTag)}`,
+    `${indent}commits to be skipped: ${JSON.stringify(options.skipCommit)}`,
     `${indent}verbose: ${JSON.stringify(options.verbose)}`,
     `${indent}changelog prepend file: ${options.changelogPrependFile}`,
     `${indent}github repo: ${JSON.stringify(getGitHubRepo(options))}`,

--- a/src/commands/get-conventional-bump.ts
+++ b/src/commands/get-conventional-bump.ts
@@ -1,11 +1,12 @@
-import { getFullPackageName } from '#lib/utils';
+import { getFullPackageName, getSHA1HashesRegexp } from '#lib/utils';
 import type { Options } from 'commander';
 import { Bumper, packagePrefix } from 'conventional-recommended-bump';
 
 export async function getConventionalBump(options: Options) {
   const bumper = new Bumper().commits(
     {
-      path: process.cwd()
+      path: process.cwd(),
+      ignore: getSHA1HashesRegexp(options.skipCommit)
     },
     {
       headerPattern: /^(\w*)(?:\((.*)\))?: (.*)$/,

--- a/src/commands/update-changelog.ts
+++ b/src/commands/update-changelog.ts
@@ -1,4 +1,4 @@
-import { doActionAndLog, getGitHubRepo, getGitHubToken, getGitRootDirection, resolveTagTemplate } from '#lib/utils';
+import { doActionAndLog, getGitHubRepo, getGitHubToken, getGitRootDirection, getSHA1HashesArray, resolveTagTemplate } from '#lib/utils';
 import { isNullishOrEmpty } from '@sapphire/utilities';
 import type { Options } from 'commander';
 import { runGitCliff, type Options as GitCliffOptions } from 'git-cliff';
@@ -7,29 +7,30 @@ export async function updateChangelog(options: Options, newVersion: string) {
   const repositoryRootDirectory = await getGitRootDirection();
 
   return doActionAndLog('Updating Changelog', async () => {
+    const gitCliffOptions: GitCliffOptions = {
+      tag: resolveTagTemplate(options, newVersion),
+      prepend: options.changelogPrependFile ?? './CHANGELOG.md',
+      unreleased: true,
+      config: './cliff.toml',
+      output: '-',
+      skipCommit: getSHA1HashesArray(options.skipCommit)
+    };
+
+    if (!isNullishOrEmpty(repositoryRootDirectory)) {
+      gitCliffOptions.repository = repositoryRootDirectory;
+      gitCliffOptions.includePath = `${options.packagePath}/*`;
+    }
+
+    const githubToken = getGitHubToken(options);
+    const githubRepo = getGitHubRepo(options);
+    if (!isNullishOrEmpty(githubRepo) && !isNullishOrEmpty(githubToken)) {
+      const resolvedGitHubRepo = githubRepo === 'auto' ? `${options.org}/${options.name}` : `${githubRepo}`;
+
+      gitCliffOptions.githubRepo = resolvedGitHubRepo;
+      gitCliffOptions.githubToken = githubToken;
+    }
+
     if (!options.dryRun) {
-      const gitCliffOptions: GitCliffOptions = {
-        tag: resolveTagTemplate(options, newVersion),
-        prepend: options.changelogPrependFile ?? './CHANGELOG.md',
-        unreleased: true,
-        config: './cliff.toml',
-        output: '-'
-      };
-
-      if (!isNullishOrEmpty(repositoryRootDirectory)) {
-        gitCliffOptions.repository = repositoryRootDirectory;
-        gitCliffOptions.includePath = `${options.packagePath}/*`;
-      }
-
-      const githubToken = getGitHubToken(options);
-      const githubRepo = getGitHubRepo(options);
-      if (!isNullishOrEmpty(githubRepo) && !isNullishOrEmpty(githubToken)) {
-        const resolvedGitHubRepo = githubRepo === 'auto' ? `${options.org}/${options.name}` : `${githubRepo}`;
-
-        gitCliffOptions.githubRepo = resolvedGitHubRepo;
-        gitCliffOptions.githubToken = githubToken;
-      }
-
       const result = await runGitCliff(gitCliffOptions, { stdio: options.githubRelease ? 'pipe' : 'ignore' });
       return result.stdout;
     }

--- a/src/lib/interfaces.d.ts
+++ b/src/lib/interfaces.d.ts
@@ -19,6 +19,7 @@ declare module 'commander' {
     commitMessageTemplate: string;
     tagTemplate: string;
     changelogPrependFile: string;
+    skipCommit: string[];
     githubRepo: string;
     githubToken: string;
     pushTag: boolean;

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -175,3 +175,34 @@ export function getGitHubRepo(options: Options): string | undefined {
 export function getGitHubToken(options: Options): string | undefined {
   return process.env.GITHUB_TOKEN ?? process.env.GH_TOKEN ?? process.env.TOKEN_GITHUB ?? process.env.TOKEN_GH ?? options.githubToken ?? undefined;
 }
+
+/**
+ * Gets SHA1 hashes for the given array of commits.
+ *
+ * @param commits - The array of commits to calculate the SHA1 hashes for.
+ * @returns The concatenated SHA1 hashes separated by a space.
+ */
+export function getSHA1HashesArray(commits: string[]): string[] {
+  return commits.filter(isValidSHA1);
+}
+
+/**
+ * Generates a regular expression pattern that matches any of the SHA1 hashes in the given array of commits.
+ *
+ * @param commits - An array of SHA1 hashes representing commits.
+ * @returns A regular expression pattern that matches any of the SHA1 hashes.
+ */
+export function getSHA1HashesRegexp(commits: string[]): RegExp {
+  return new RegExp(getSHA1HashesArray(commits).join('|'));
+}
+
+const sha1regex = /^[a-fA-F0-9]{40}$/;
+/**
+ * Checks if a given string is a valid SHA1 hash.
+ *
+ * @param string - The string to be checked.
+ * @returns `true` if the string is a valid SHA1 hash, `false` otherwise.
+ */
+function isValidSHA1(string: string): boolean {
+  return sha1regex.test(string);
+}


### PR DESCRIPTION
Resolves #200

This implements commit skipping for git-cliff and conventional-recommended-bump.

Blocked by https://github.com/orhun/git-cliff/pull/843 being merged and released

Tested manually. Skipping the 2 `feat` commits from this PR I get a version of 4.1.1 (instead of 4.2.0) and changelog with:
```diff
diff --git a/CHANGELOG.md b/CHANGELOG.md
index 83af0f8..21b61a1 100644
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to this project will be documented in this file.
 
+# [@favware/cliff-jumper@4.1.1](https://github.com///compare/@favware/cliff-jumper@4.1.0...@favware/cliff-jumper@4.1.1) - (2024-09-07)
+
+## 🏠 Refactor
+
+- Parse git cliff options regardless of dry-run, only do not run git-cliff ([6096c30](https://github.com///commit/6096c306a30fb8bb745033e169a04ff88a83335c))
+
+## 🐛 Bug Fixes
+
+- Use proper option name ([181c484](https://github.com///commit/181c484840117bf581d7e449656dd6bb8aad9a5d))
+
+## 📝 Documentation
+
+- Update readme and json schema ([ebaa39e](https://github.com///commit/ebaa39ed8d13ce81d6b237905845d1ff3154116d))
+
 # [@favware/cliff-jumper@4.1.0](https://github.com/favware/cliff-jumper/compare/@favware/cliff-jumper@4.0.3...@favware/cliff-jumper@4.1.0) - (2024-08-24)
 
 ## 🐛 Bug Fixes
```